### PR TITLE
Fix is_directory deprecation message

### DIFF
--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -228,7 +228,7 @@ pub fn append_bits(
 /// let assert True = is_directory("./test")
 /// ```
 /// 
-@deprecated("Use `is_valid_directory` instead")
+@deprecated("Use `verify_is_directory` instead")
 pub fn is_directory(filepath: String) -> Bool {
   do_is_directory(filepath)
 }
@@ -353,7 +353,10 @@ pub fn rename_file(at src: String, to dest: String) -> Result(Nil, FileError) {
 }
 
 /// Copy a directory recursively
-pub fn copy_directory(at src: String, to dest: String) -> Result(Nil, FileError) {
+pub fn copy_directory(
+  at src: String,
+  to dest: String,
+) -> Result(Nil, FileError) {
   // Erlang does not provide a built in `copy_dir` function, 
   // and Deno doesn't support Node's `fs.cpSync`, so we'll just roll 
   // our own for now.


### PR DESCRIPTION
just noticed that the 0.34 formatter also kicked in 😬