### PR TITLE
fix fileninfo attribute names for the js target

### DIFF
--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -237,12 +237,12 @@ class FileInfo {
         this.mode = stat.mode
         this.nlinks = stat.nlink
         this.inode = stat.ino
-        this.userId = stat.uid
-        this.groupId = stat.gid
+        this.user_id = stat.uid
+        this.group_id = stat.gid
         this.dev = stat.dev
-        this.atime = Math.floor(stat.atimeMs / 1000)
-        this.mtime = Math.floor(stat.mtimeMs / 1000)
-        this.ctime = Math.floor(stat.ctimeMs / 1000)
+        this.atime_seconds = Math.floor(stat.atimeMs / 1000)
+        this.mtime_seconds = Math.floor(stat.mtimeMs / 1000)
+        this.ctime_seconds = Math.floor(stat.ctimeMs / 1000)
     }
 }
 


### PR DESCRIPTION
I adjusted the attribute names to align with the respective names of the gleam record type. previously, these attributes would just be Nil