### PR TITLE
Remove target annotation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.2"
-          gleam-version: "1.0.0"
+          gleam-version: "1.2.0"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -255,8 +255,8 @@ pub fn write(
 /// ```gleam
 /// let assert Ok(Nil) = delete(file_at: "./delete_me.txt")
 /// ```
-@external(erlang, "simplifile_erl", "recursive_delete")
-@external(javascript, "./simplifile_js.mjs", "deleteFileOrDirRecursive")
+@external(erlang, "simplifile_erl", "delete")
+@external(javascript, "./simplifile_js.mjs", "delete_")
 pub fn delete(file_or_dir_at path: String) -> Result(Nil, FileError)
 
 /// Delete all files/directories specified in a list of paths.
@@ -296,7 +296,7 @@ pub fn append(
 /// ```gleam
 /// let assert Ok(records) = read_bits(from: "./users.csv")
 /// ```
-@external(erlang, "simplifile_erl", "read_file")
+@external(erlang, "simplifile_erl", "read_bits")
 @external(javascript, "./simplifile_js.mjs", "readBits")
 pub fn read_bits(from filepath: String) -> Result(BitArray, FileError)
 
@@ -306,7 +306,7 @@ pub fn read_bits(from filepath: String) -> Result(BitArray, FileError)
 /// let assert Ok(Nil) = write_bits(to: "./hello_world.txt", bits: <<"Hello, World!":utf8>>)
 /// ```
 ///
-@external(erlang, "simplifile_erl", "write_file")
+@external(erlang, "simplifile_erl", "write_bits")
 @external(javascript, "./simplifile_js.mjs", "writeBits")
 pub fn write_bits(
   to filepath: String,
@@ -319,7 +319,7 @@ pub fn write_bits(
 /// let assert Ok(Nil) = append_bits(to: "./needs_more_text.txt", bits: <<"more text":utf8>>)
 /// ```
 ///
-@external(erlang, "simplifile_erl", "append_file")
+@external(erlang, "simplifile_erl", "append_bits")
 @external(javascript, "./simplifile_js.mjs", "appendBits")
 pub fn append_bits(
   to filepath: String,
@@ -333,8 +333,8 @@ pub fn append_bits(
 /// ```gleam
 /// let assert Ok(True) = is_directory("./test")
 /// ```
-@external(erlang, "simplifile_erl", "is_valid_directory")
-@external(javascript, "./simplifile_js.mjs", "isValidDirectory")
+@external(erlang, "simplifile_erl", "is_directory")
+@external(javascript, "./simplifile_js.mjs", "isDirectory")
 pub fn is_directory(filepath: String) -> Result(Bool, FileError)
 
 /// Create a directory at the provided filepath. Returns an error if
@@ -344,8 +344,8 @@ pub fn is_directory(filepath: String) -> Result(Bool, FileError)
 /// ```gleam
 /// create_directory("./test")
 /// ```
-@external(erlang, "simplifile_erl", "make_directory")
-@external(javascript, "./simplifile_js.mjs", "makeDirectory")
+@external(erlang, "simplifile_erl", "create_directory")
+@external(javascript, "./simplifile_js.mjs", "createDirectory")
 pub fn create_directory(filepath: String) -> Result(Nil, FileError)
 
 /// Create a symbolic link called symlink pointing to target.
@@ -354,8 +354,8 @@ pub fn create_directory(filepath: String) -> Result(Nil, FileError)
 /// ```gleam
 /// create_symlink("../target", "./symlink")
 /// ```
-@external(erlang, "simplifile_erl", "make_symlink")
-@external(javascript, "./simplifile_js.mjs", "makeSymlink")
+@external(erlang, "simplifile_erl", "create_symlink")
+@external(javascript, "./simplifile_js.mjs", "createSymlink")
 pub fn create_symlink(
   to target: String,
   from symlink: String,
@@ -369,8 +369,8 @@ pub fn create_symlink(
 /// let assert Ok(files_and_folders) = read_directory(at: "./Folder1")
 /// ```
 ///
-@external(erlang, "simplifile_erl", "list_directory")
-@external(javascript, "./simplifile_js.mjs", "listContents")
+@external(erlang, "simplifile_erl", "read_directory")
+@external(javascript, "./simplifile_js.mjs", "readDirectory")
 pub fn read_directory(at path: String) -> Result(List(String), FileError)
 
 /// Checks if the file at the provided filepath exists and is a file.
@@ -381,8 +381,8 @@ pub fn read_directory(at path: String) -> Result(List(String), FileError)
 /// let assert Ok(True) = is_file("./test.txt")
 /// ```
 ///
-@external(erlang, "simplifile_erl", "is_valid_file")
-@external(javascript, "./simplifile_js.mjs", "isValidFile")
+@external(erlang, "simplifile_erl", "is_file")
+@external(javascript, "./simplifile_js.mjs", "isFile")
 pub fn is_file(filepath: String) -> Result(Bool, FileError)
 
 /// Checks if the file at the provided filepath exists and is a symbolic link.
@@ -393,8 +393,8 @@ pub fn is_file(filepath: String) -> Result(Bool, FileError)
 /// let assert Ok(True) = is_symlink("./symlink")
 /// ```
 ///
-@external(erlang, "simplifile_erl", "is_valid_symlink")
-@external(javascript, "./simplifile_js.mjs", "isValidSymlink")
+@external(erlang, "simplifile_erl", "is_symlink")
+@external(javascript, "./simplifile_js.mjs", "isSymlink")
 pub fn is_symlink(filepath: String) -> Result(Bool, FileError)
 
 /// Creates an empty file at the given filepath. Returns an `Error(Eexist)`
@@ -587,8 +587,8 @@ pub fn set_permissions(
 /// ```gleam
 /// set_permissions_octal("./script.sh", 0o777)
 /// ```
-@external(erlang, "simplifile_erl", "set_permissions")
-@external(javascript, "./simplifile_js.mjs", "setPermissions")
+@external(erlang, "simplifile_erl", "set_permissions_octal")
+@external(javascript, "./simplifile_js.mjs", "setPermissionsOctal")
 pub fn set_permissions_octal(
   for_file_at filepath: String,
   to permissions: Int,

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -4,7 +4,6 @@ import gleam/int
 import gleam/list
 import gleam/result
 import gleam/set.{type Set}
-@target(erlang)
 import gleam/string
 
 /// This type represents all of the reasons for why a file system operation could fail.
@@ -211,19 +210,10 @@ pub type FileInfo {
   )
 }
 
-@target(erlang)
-@external(erlang, "simplifile_erl", "file_info")
-fn do_file_info(a: String) -> Result(FileInfo, FileError)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "fileInfo")
-fn do_file_info(a: String) -> Result(FileInfo, String)
-
 /// Get information about a file at a given path
-pub fn file_info(a: String) -> Result(FileInfo, FileError) {
-  do_file_info(a)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "file_info")
+@external(javascript, "./simplifile_js.mjs", "fileInfo")
+pub fn file_info(filepath: String) -> Result(FileInfo, FileError)
 
 /// Read a files contents as a string
 /// ## Example
@@ -232,8 +222,15 @@ pub fn file_info(a: String) -> Result(FileInfo, FileError) {
 /// ```
 ///
 pub fn read(from filepath: String) -> Result(String, FileError) {
-  do_read(filepath)
-  |> cast_error
+  case read_bits(filepath) {
+    Ok(bits) -> {
+      case bit_array.to_string(bits) {
+        Ok(str) -> Ok(str)
+        _ -> Error(NotUtf8)
+      }
+    }
+    Error(e) -> Error(e)
+  }
 }
 
 /// Write a string to a file at the given path
@@ -246,8 +243,9 @@ pub fn write(
   to filepath: String,
   contents contents: String,
 ) -> Result(Nil, FileError) {
-  do_write(contents, to: filepath)
-  |> cast_error
+  contents
+  |> bit_array.from_string
+  |> write_bits(to: filepath)
 }
 
 /// Delete a file or directory at a given path. Performs a recursive
@@ -257,11 +255,9 @@ pub fn write(
 /// ```gleam
 /// let assert Ok(Nil) = delete(file_at: "./delete_me.txt")
 /// ```
-///
-pub fn delete(file_or_dir_at path: String) -> Result(Nil, FileError) {
-  do_delete(path)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "recursive_delete")
+@external(javascript, "./simplifile_js.mjs", "deleteFileOrDirRecursive")
+pub fn delete(file_or_dir_at path: String) -> Result(Nil, FileError)
 
 /// Delete all files/directories specified in a list of paths.
 /// Recursively deletes provided directories.
@@ -290,8 +286,9 @@ pub fn append(
   to filepath: String,
   contents contents: String,
 ) -> Result(Nil, FileError) {
-  do_append(contents, to: filepath)
-  |> cast_error
+  contents
+  |> bit_array.from_string
+  |> append_bits(to: filepath)
 }
 
 /// Read a files contents as a bitstring
@@ -299,11 +296,9 @@ pub fn append(
 /// ```gleam
 /// let assert Ok(records) = read_bits(from: "./users.csv")
 /// ```
-///
-pub fn read_bits(from filepath: String) -> Result(BitArray, FileError) {
-  do_read_bits(filepath)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "read_file")
+@external(javascript, "./simplifile_js.mjs", "readBits")
+pub fn read_bits(from filepath: String) -> Result(BitArray, FileError)
 
 /// Write a bitstring to a file at the given path
 /// ## Example
@@ -311,13 +306,12 @@ pub fn read_bits(from filepath: String) -> Result(BitArray, FileError) {
 /// let assert Ok(Nil) = write_bits(to: "./hello_world.txt", bits: <<"Hello, World!":utf8>>)
 /// ```
 ///
+@external(erlang, "simplifile_erl", "write_file")
+@external(javascript, "./simplifile_js.mjs", "writeBits")
 pub fn write_bits(
   to filepath: String,
   bits bits: BitArray,
-) -> Result(Nil, FileError) {
-  do_write_bits(bits, filepath)
-  |> cast_error
-}
+) -> Result(Nil, FileError)
 
 /// Append a bitstring to the contents of a file at the given path
 /// ## Example
@@ -325,13 +319,12 @@ pub fn write_bits(
 /// let assert Ok(Nil) = append_bits(to: "./needs_more_text.txt", bits: <<"more text":utf8>>)
 /// ```
 ///
+@external(erlang, "simplifile_erl", "append_file")
+@external(javascript, "./simplifile_js.mjs", "appendBits")
 pub fn append_bits(
   to filepath: String,
   bits bits: BitArray,
-) -> Result(Nil, FileError) {
-  do_append_bits(bits, filepath)
-  |> cast_error
-}
+) -> Result(Nil, FileError)
 
 /// Checks if the provided filepath exists and is a directory.
 /// Returns an error if it lacks permissions to read the directory.
@@ -340,18 +333,9 @@ pub fn append_bits(
 /// ```gleam
 /// let assert Ok(True) = is_directory("./test")
 /// ```
-pub fn is_directory(filepath: String) -> Result(Bool, FileError) {
-  do_verify_is_directory(filepath)
-  |> cast_error
-}
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "isValidDirectory")
-fn do_verify_is_directory(filepath: String) -> Result(Bool, String)
-
-@target(erlang)
 @external(erlang, "simplifile_erl", "is_valid_directory")
-fn do_verify_is_directory(filepath: String) -> Result(Bool, FileError)
+@external(javascript, "./simplifile_js.mjs", "isValidDirectory")
+pub fn is_directory(filepath: String) -> Result(Bool, FileError)
 
 /// Create a directory at the provided filepath. Returns an error if
 /// the directory already exists.
@@ -360,10 +344,9 @@ fn do_verify_is_directory(filepath: String) -> Result(Bool, FileError)
 /// ```gleam
 /// create_directory("./test")
 /// ```
-pub fn create_directory(filepath: String) -> Result(Nil, FileError) {
-  do_make_directory(filepath)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "make_directory")
+@external(javascript, "./simplifile_js.mjs", "makeDirectory")
+pub fn create_directory(filepath: String) -> Result(Nil, FileError)
 
 /// Create a symbolic link called symlink pointing to target.
 ///
@@ -371,13 +354,12 @@ pub fn create_directory(filepath: String) -> Result(Nil, FileError) {
 /// ```gleam
 /// create_symlink("../target", "./symlink")
 /// ```
+@external(erlang, "simplifile_erl", "make_symlink")
+@external(javascript, "./simplifile_js.mjs", "makeSymlink")
 pub fn create_symlink(
   to target: String,
   from symlink: String,
-) -> Result(Nil, FileError) {
-  do_make_symlink(target, symlink)
-  |> cast_error
-}
+) -> Result(Nil, FileError)
 
 /// Lists the contents of a directory.
 /// The list contains directory and file names, and is not recursive.
@@ -387,10 +369,9 @@ pub fn create_symlink(
 /// let assert Ok(files_and_folders) = read_directory(at: "./Folder1")
 /// ```
 ///
-pub fn read_directory(at path: String) -> Result(List(String), FileError) {
-  do_read_directory(path)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "list_directory")
+@external(javascript, "./simplifile_js.mjs", "listContents")
+pub fn read_directory(at path: String) -> Result(List(String), FileError)
 
 /// Checks if the file at the provided filepath exists and is a file.
 /// Returns an Error if it lacks permissions to read the file.
@@ -400,18 +381,9 @@ pub fn read_directory(at path: String) -> Result(List(String), FileError) {
 /// let assert Ok(True) = is_file("./test.txt")
 /// ```
 ///
-pub fn is_file(filepath: String) -> Result(Bool, FileError) {
-  do_verify_is_file(filepath)
-  |> cast_error
-}
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "isValidFile")
-fn do_verify_is_file(filepath: String) -> Result(Bool, String)
-
-@target(erlang)
 @external(erlang, "simplifile_erl", "is_valid_file")
-fn do_verify_is_file(filepath: String) -> Result(Bool, FileError)
+@external(javascript, "./simplifile_js.mjs", "isValidFile")
+pub fn is_file(filepath: String) -> Result(Bool, FileError)
 
 /// Checks if the file at the provided filepath exists and is a symbolic link.
 /// Returns an Error if it lacks permissions to read the file.
@@ -421,29 +393,15 @@ fn do_verify_is_file(filepath: String) -> Result(Bool, FileError)
 /// let assert Ok(True) = is_symlink("./symlink")
 /// ```
 ///
-pub fn is_symlink(filepath: String) -> Result(Bool, FileError) {
-  do_verify_is_symlink(filepath)
-  |> cast_error
-}
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "isValidSymlink")
-fn do_verify_is_symlink(filepath: String) -> Result(Bool, String)
-
-@target(erlang)
 @external(erlang, "simplifile_erl", "is_valid_symlink")
-fn do_verify_is_symlink(filepath: String) -> Result(Bool, FileError)
+@external(javascript, "./simplifile_js.mjs", "isValidSymlink")
+pub fn is_symlink(filepath: String) -> Result(Bool, FileError)
 
 /// Creates an empty file at the given filepath. Returns an `Error(Eexist)`
 /// if the file already exists.
 ///
 pub fn create_file(at filepath: String) -> Result(Nil, FileError) {
-  case
-    filepath
-    |> is_file,
-    filepath
-    |> is_directory
-  {
+  case filepath |> is_file, filepath |> is_directory {
     Ok(True), _ | _, Ok(True) -> Error(Eexist)
     _, _ -> write_bits(<<>>, to: filepath)
   }
@@ -464,23 +422,28 @@ pub fn create_directory_all(dirpath: String) -> Result(Nil, FileError) {
     False -> path
   }
   do_create_dir_all(path <> "/")
-  |> cast_error
 }
+
+@external(erlang, "simplifile_erl", "create_dir_all")
+@external(javascript, "./simplifile_js.mjs", "createDirAll")
+fn do_create_dir_all(dirpath: String) -> Result(Nil, FileError)
 
 /// Copy a file at a given path to another path.
 /// Note: destination should include the filename, not just the directory
 pub fn copy_file(at src: String, to dest: String) -> Result(Nil, FileError) {
   do_copy_file(src, dest)
   |> result.replace(Nil)
-  |> cast_error
 }
+
+@external(erlang, "file", "copy")
+@external(javascript, "./simplifile_js.mjs", "copyFile")
+fn do_copy_file(src: String, dest: String) -> Result(Int, FileError)
 
 /// Rename a file at a given path to another path.
 /// Note: destination should include the filename, not just the directory
-pub fn rename_file(at src: String, to dest: String) -> Result(Nil, FileError) {
-  do_rename_file(src, dest)
-  |> cast_error
-}
+@external(erlang, "simplifile_erl", "rename_file")
+@external(javascript, "./simplifile_js.mjs", "renameFile")
+pub fn rename_file(at src: String, to dest: String) -> Result(Nil, FileError)
 
 /// Copy a directory recursively
 pub fn copy_directory(at src: String, to dest: String) -> Result(Nil, FileError) {
@@ -624,247 +587,20 @@ pub fn set_permissions(
 /// ```gleam
 /// set_permissions_octal("./script.sh", 0o777)
 /// ```
+@external(erlang, "simplifile_erl", "set_permissions")
+@external(javascript, "./simplifile_js.mjs", "setPermissions")
 pub fn set_permissions_octal(
   for_file_at filepath: String,
   to permissions: Int,
-) -> Result(Nil, FileError) {
-  do_set_permissions(filepath, permissions)
-  |> cast_error
-}
+) -> Result(Nil, FileError)
 
 /// Returns the current working directory
 ///
-pub fn current_directory() -> Result(String, FileError) {
-  do_current_directory()
-  |> cast_error
-}
-
-@target(javascript)
 @external(javascript, "./simplifile_js.mjs", "currentDirectory")
-fn do_current_directory() -> Result(String, String)
-
-@target(erlang)
-fn do_current_directory() -> Result(String, FileError) {
-  do_do_current_directory()
+pub fn current_directory() -> Result(String, FileError) {
+  erl_do_current_directory()
   |> result.map(string.from_utf_codepoints)
 }
 
-@target(erlang)
 @external(erlang, "file", "get_cwd")
-fn do_do_current_directory() -> Result(List(UtfCodepoint), FileError)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "setPermissions")
-fn do_set_permissions(
-  file_at: String,
-  permissions_octal: Int,
-) -> Result(Nil, String)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "set_permissions")
-fn do_set_permissions(
-  file_at: String,
-  permissions_octal: Int,
-) -> Result(Nil, FileError)
-
-@target(javascript)
-fn do_read(from filepath: String) -> Result(String, String) {
-  case do_read_bits(filepath) {
-    Ok(bits) -> {
-      case bit_array.to_string(bits) {
-        Ok(str) -> Ok(str)
-        _ -> Error("NOTUTF8")
-      }
-    }
-    Error(e) -> Error(e)
-  }
-}
-
-@target(javascript)
-fn do_write(content: String, to filepath: String) -> Result(Nil, String) {
-  content
-  |> bit_array.from_string
-  |> do_write_bits(to: filepath)
-}
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "deleteFileOrDirRecursive")
-fn do_delete(file_or_dir_at: String) -> Result(Nil, String)
-
-@target(javascript)
-fn do_append(content: String, to filepath: String) -> Result(Nil, String) {
-  content
-  |> bit_array.from_string
-  |> do_append_bits(to: filepath)
-}
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "readBits")
-fn do_read_bits(from: String) -> Result(BitArray, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "writeBits")
-fn do_write_bits(content: BitArray, to filepath: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "appendBits")
-fn do_append_bits(content: BitArray, to filepath: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "makeDirectory")
-fn do_make_directory(filepath: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "makeSymlink")
-fn do_make_symlink(target: String, symlink: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "createDirAll")
-fn do_create_dir_all(dirpath: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "listContents")
-fn do_read_directory(directory_path: String) -> Result(List(String), String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "copyFile")
-fn do_copy_file(at: String, to: String) -> Result(Nil, String)
-
-@target(javascript)
-@external(javascript, "./simplifile_js.mjs", "renameFile")
-fn do_rename_file(at: String, to: String) -> Result(Nil, String)
-
-@target(javascript)
-fn cast_error(input: Result(a, String)) -> Result(a, FileError) {
-  result.map_error(input, fn(e) {
-    case e {
-      "EACCES" -> Eacces
-      "EAGAIN" -> Eagain
-      "EBADF" -> Ebadf
-      "EBADMSG" -> Ebadmsg
-      "EBUSY" -> Ebusy
-      "EDEADLK" -> Edeadlk
-      "EDEADLOCK" -> Edeadlock
-      "EDQUOT" -> Edquot
-      "EEXIST" -> Eexist
-      "EFAULT" -> Efault
-      "EFBIG" -> Efbig
-      "EFTYPE" -> Eftype
-      "EINTR" -> Eintr
-      "EINVAL" -> Einval
-      "EIO" -> Eio
-      "EISDIR" -> Eisdir
-      "ELOOP" -> Eloop
-      "EMFILE" -> Emfile
-      "EMLINK" -> Emlink
-      "EMULTIHOP" -> Emultihop
-      "ENAMETOOLONG" -> Enametoolong
-      "ENFILE" -> Enfile
-      "ENOBUFS" -> Enobufs
-      "ENODEV" -> Enodev
-      "ENOLCK" -> Enolck
-      "ENOLINK" -> Enolink
-      "ENOENT" -> Enoent
-      "ENOMEM" -> Enomem
-      "ENOSPC" -> Enospc
-      "ENOSR" -> Enosr
-      "ENOSTR" -> Enostr
-      "ENOSYS" -> Enosys
-      "ENOBLK" -> Enotblk
-      "ENODIR" -> Enotdir
-      "ENOTSUP" -> Enotsup
-      "ENXIO" -> Enxio
-      "EOPNOTSUPP" -> Eopnotsupp
-      "EOVERFLOW" -> Eoverflow
-      "EPERM" -> Eperm
-      "EPIPE" -> Epipe
-      "ERANGE" -> Erange
-      "EROFS" -> Erofs
-      "ESPIPE" -> Espipe
-      "ESRCH" -> Esrch
-      "ESTALE" -> Estale
-      "ETXTBSY" -> Etxtbsy
-      "EXDEV" -> Exdev
-      "NOTUTF8" -> NotUtf8
-      str -> Unknown(str)
-    }
-  })
-}
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "append_file")
-fn do_append_bits(
-  content: BitArray,
-  to filepath: String,
-) -> Result(Nil, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "write_file")
-fn do_write_bits(
-  content: BitArray,
-  to filepath: String,
-) -> Result(Nil, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "read_file")
-fn do_read_bits(from: String) -> Result(BitArray, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "recursive_delete")
-fn do_delete(file_or_dir_at: String) -> Result(Nil, FileError)
-
-@target(erlang)
-fn do_append(content: String, to filepath: String) -> Result(Nil, FileError) {
-  content
-  |> bit_array.from_string
-  |> do_append_bits(filepath)
-}
-
-@target(erlang)
-fn do_write(content: String, to filepath: String) -> Result(Nil, FileError) {
-  content
-  |> bit_array.from_string
-  |> do_write_bits(filepath)
-}
-
-@target(erlang)
-fn do_read(from filepath: String) -> Result(String, FileError) {
-  case do_read_bits(filepath) {
-    Ok(bits) -> {
-      case bit_array.to_string(bits) {
-        Ok(str) -> Ok(str)
-        _ -> Error(NotUtf8)
-      }
-    }
-    Error(e) -> Error(e)
-  }
-}
-
-@target(erlang)
-fn cast_error(input: Result(a, FileError)) -> Result(a, FileError) {
-  input
-}
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "make_directory")
-fn do_make_directory(directory: String) -> Result(Nil, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "make_symlink")
-fn do_make_symlink(target: String, symlink: String) -> Result(Nil, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "list_directory")
-fn do_read_directory(directory: String) -> Result(List(String), FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "create_dir_all")
-fn do_create_dir_all(dirpath: String) -> Result(Nil, FileError)
-
-@target(erlang)
-@external(erlang, "file", "copy")
-fn do_copy_file(src: String, dest: String) -> Result(Int, FileError)
-
-@target(erlang)
-@external(erlang, "simplifile_erl", "rename_file")
-fn do_rename_file(src: String, dest: String) -> Result(Nil, FileError)
+fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)

--- a/src/simplifile_erl.erl
+++ b/src/simplifile_erl.erl
@@ -7,9 +7,24 @@
 -module(simplifile_erl).
 
 %% API
--export([read_file/1, append_file/2, write_file/2, delete_file/1, delete_directory/1,
-         recursive_delete/1, list_directory/1, make_directory/1, make_symlink/2, create_dir_all/1, rename_file/2, set_permissions/2,
-         is_valid_directory/1, is_valid_file/1, is_valid_symlink/1, file_info/1]).
+-export([
+    append_bits/2,
+    create_directory/1,
+    create_dir_all/1,
+    delete_file/1,
+    create_symlink/2,
+    delete/1,
+    delete_directory/1,
+    file_info/1,
+    is_directory/1,
+    is_file/1,
+    is_symlink/1,
+    read_bits/1,
+    read_directory/1,
+    rename_file/2,
+    set_permissions_octal/2,
+    write_bits/2
+]).
 
 -include_lib("kernel/include/file.hrl").
 
@@ -76,15 +91,15 @@ posix_result(Result) ->
     end.
 
 %% Read the binary contents of a file
-read_file(Filename) ->
+read_bits(Filename) ->
     posix_result(file:read_file(Filename)).
 
 %% Write bytes to a file
-write_file(Filename, Contents) ->
+write_bits(Filename, Contents) ->
     posix_result(file:write_file(Filename, Contents)).
 
 %% Append bytes to a file
-append_file(Filename, Contents) ->
+append_bits(Filename, Contents) ->
     posix_result(file:write_file(Filename, Contents, [append])).
 
 %% Delete the file at the given path
@@ -92,15 +107,15 @@ delete_file(Filename) ->
     posix_result(file:delete(Filename)).
 
 %% Create a directory at the given path. Missing parent directories are not created.
-make_directory(Dir) ->
+create_directory(Dir) ->
     posix_result(file:make_dir(Dir)).
 
 %% Create a symbolic link New to the file or directory Existing (does not need to exist).
-make_symlink(Existing, New) ->
+create_symlink(Existing, New) ->
     posix_result(file:make_symlink(Existing, New)).
 
 %% List the contents of a directory
-list_directory(Dir) ->
+read_directory(Dir) ->
     case file:list_dir(Dir) of
         {ok, Filenames} ->
             {ok, [unicode:characters_to_binary(Filename) || Filename <- Filenames]};
@@ -113,7 +128,7 @@ delete_directory(Dir) ->
     posix_result(file:del_dir(Dir)).
 
 %% Deletes a file/directory and everything in it.
-recursive_delete(Dir) ->
+delete(Dir) ->
     posix_result(file:del_dir_r(Dir)).
 
 %% Creates the entire path for a given directory to exist
@@ -125,10 +140,10 @@ rename_file(Source, Destination) ->
     posix_result(file:rename(Source, Destination)).
 
 %% Set the permissions for the given file.
-set_permissions(Filename, Permissions) ->
+set_permissions_octal(Filename, Permissions) ->
     posix_result(file:change_mode(Filename, Permissions)).
 
-is_valid_directory(Path) ->
+is_directory(Path) ->
     case file:read_file_info(Path) of
         {ok, FileInfo} ->
             case FileInfo#file_info.type of
@@ -143,7 +158,7 @@ is_valid_directory(Path) ->
             posix_result({error, Reason})
     end.
 
-is_valid_file(Path) ->
+is_file(Path) ->
     case file:read_file_info(Path) of
         {ok, FileInfo} ->
             case FileInfo#file_info.type of
@@ -158,7 +173,7 @@ is_valid_file(Path) ->
             posix_result({error, Reason})
     end.
 
-is_valid_symlink(Path) ->
+is_symlink(Path) ->
     case file:read_link_info(Path) of
         {ok, FileInfo} ->
             case FileInfo#file_info.type of

--- a/src/simplifile_erl.erl
+++ b/src/simplifile_erl.erl
@@ -80,11 +80,11 @@ read_file(Filename) ->
     posix_result(file:read_file(Filename)).
 
 %% Write bytes to a file
-write_file(Contents, Filename) ->
+write_file(Filename, Contents) ->
     posix_result(file:write_file(Filename, Contents)).
 
 %% Append bytes to a file
-append_file(Contents, Filename) ->
+append_file(Filename, Contents) ->
     posix_result(file:write_file(Filename, Contents, [append])).
 
 %% Delete the file at the given path

--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -47,7 +47,7 @@ export function appendBits(filepath, contents) {
  * @param {string} filepath
  * @returns {Ok | GError}
  */
-export function isValidFile(filepath) {
+export function isFile(filepath) {
   try {
     return new Ok(fs.statSync(path.normalize(filepath)).isFile());
   } catch (e) {
@@ -65,7 +65,7 @@ export function isValidFile(filepath) {
  * @param {string} filepath
  * @returns {Ok | GError}
  */
-export function isValidSymlink(filepath) {
+export function isSymlink(filepath) {
   try {
     return new Ok(fs.lstatSync(path.normalize(filepath)).isSymbolicLink());
   } catch (e) {
@@ -83,7 +83,7 @@ export function isValidSymlink(filepath) {
  * @param {string} filepath
  * @returns {Ok | GError}
  */
-export function isValidDirectory(filepath) {
+export function isDirectory(filepath) {
   try {
     return new Ok(fs.statSync(path.normalize(filepath)).isDirectory());
   } catch (e) {
@@ -102,7 +102,7 @@ export function isValidDirectory(filepath) {
  * @param {string} path
  * @returns {Ok | GError}
  */
-export function makeSymlink(target, path) {
+export function createSymlink(target, path) {
   return gleamResult(() => fs.symlinkSync(target, path));
 }
 
@@ -112,7 +112,7 @@ export function makeSymlink(target, path) {
  * @param {string} filepath
  * @returns {Ok | GError}
  */
-export function makeDirectory(filepath) {
+export function createDirectory(filepath) {
   return gleamResult(() => fs.mkdirSync(path.normalize(filepath)));
 }
 
@@ -134,9 +134,9 @@ export function createDirAll(filepath) {
  * @param {string} fileOrDirPath
  * @returns {Ok | GError}
  */
-export function deleteFileOrDirRecursive(fileOrDirPath) {
+export function delete_(fileOrDirPath) {
   return gleamResult(() => {
-    const isDir = isValidDirectory(fileOrDirPath);
+    const isDir = isDirectory(fileOrDirPath);
     if (isDir instanceof Ok && isDir[0] === true) {
       fs.rmSync(path.normalize(fileOrDirPath), { recursive: true });
     } else {
@@ -151,7 +151,7 @@ export function deleteFileOrDirRecursive(fileOrDirPath) {
  * @param {string} filepath
  * @returns {Ok | GError}
  */
-export function listContents(filepath) {
+export function readDirectory(filepath) {
   return gleamResult(() => toList(fs.readdirSync(path.normalize(filepath))));
 }
 
@@ -184,7 +184,7 @@ export function renameFile(srcpath, destpath) {
  * @param {number} octalNumber
  * @returns {Ok | GError}
  */
-export function setPermissions(filepath, octalNumber) {
+export function setPermissionsOctal(filepath, octalNumber) {
   return gleamResult(() => fs.chmodSync(path.normalize(filepath), octalNumber));
 }
 

--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -54,7 +54,7 @@ export function isFile(filepath) {
     if (e.code === "ENOENT") {
       return new Ok(false);
     } else {
-      return new GError(e.code);
+      return new GError(cast_error(e.code));
     }
   }
 }
@@ -72,7 +72,7 @@ export function isSymlink(filepath) {
     if (e.code === "ENOENT") {
       return new Ok(false);
     } else {
-      return new GError(e.code);
+      return new GError(cast_error(e.code));
     }
   }
 }
@@ -90,7 +90,7 @@ export function isDirectory(filepath) {
     if (e.code === "ENOENT") {
       return new Ok(false);
     } else {
-      return new GError(e.code);
+      return new GError(cast_error(e.code));
     }
   }
 }
@@ -120,7 +120,7 @@ export function createDirectory(filepath) {
  * Recursively create a directory structure from the given path.
  *
  * @param {string} filepath
- * @returns
+ * @returns {Ok | GError}
  */
 export function createDirAll(filepath) {
   return gleamResult(() => {

--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -1,61 +1,62 @@
 // @ts-check
 
-import fs from "node:fs"
-import path from "node:path"
-import process from "node:process"
-import { BitArray, Ok, Error as GError, toList} from "./gleam.mjs";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { BitArray, Ok, Error as GError, toList } from "./gleam.mjs";
+import * as $simplifile from "./simplifile.mjs";
 
 /**
- * Read the contents of a file as a BitArray 
- * 
- * @param {string} filepath 
+ * Read the contents of a file as a BitArray
+ *
+ * @param {string} filepath
  * @returns {Ok | GError} A Result with the BitArray of the file contents
  */
 export function readBits(filepath) {
-    return gleamResult(() => {
-        const contents = fs.readFileSync(path.normalize(filepath))
-        return new BitArray(new Uint8Array(contents))
-    })
+  return gleamResult(() => {
+    const contents = fs.readFileSync(path.normalize(filepath));
+    return new BitArray(new Uint8Array(contents));
+  });
 }
 
 /**
  * Write the given BitArray to a file
- * 
- * @param {BitArray} contents 
- * @param {string} filepath 
- * @returns {Ok | GError} 
+ *
+ * @param {string} filepath
+ * @param {BitArray} contents
+ * @returns {Ok | GError}
  */
-export function writeBits(contents, filepath) {
-    return gleamResult(() => fs.writeFileSync(path.normalize(filepath), contents.buffer))
+export function writeBits(filepath, contents) {
+  return gleamResult(() => fs.writeFileSync(path.normalize(filepath), contents.buffer));
 }
 
 /**
  * Append the given BitArray to a file
- * 
- * @param {BitArray} contents 
- * @param {string} filepath 
+ *
+ * @param {string} filepath
+ * @param {BitArray} contents
  * @returns {Ok | GError}
  */
-export function appendBits(contents, filepath) {
-    return gleamResult(() => fs.appendFileSync(path.normalize(filepath), contents.buffer))
+export function appendBits(filepath, contents) {
+  return gleamResult(() => fs.appendFileSync(path.normalize(filepath), contents.buffer));
 }
 
 /**
  * Check whether a file exists at the given path
- * 
- * @param {string} filepath 
- * @returns {Ok | GError} 
+ *
+ * @param {string} filepath
+ * @returns {Ok | GError}
  */
 export function isValidFile(filepath) {
-    try {
-        return new Ok(fs.statSync(path.normalize(filepath)).isFile());
-    } catch (e) {
-        if (e.code === 'ENOENT') {
-            return new Ok(false);
-        } else {
-            return new GError(e.code);
-        }
+  try {
+    return new Ok(fs.statSync(path.normalize(filepath)).isFile());
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return new Ok(false);
+    } else {
+      return new GError(e.code);
     }
+  }
 }
 
 /**
@@ -65,33 +66,33 @@ export function isValidFile(filepath) {
  * @returns {Ok | GError}
  */
 export function isValidSymlink(filepath) {
-    try {
-        return new Ok(fs.lstatSync(path.normalize(filepath)).isSymbolicLink());
-    } catch (e) {
-        if (e.code === 'ENOENT') {
-            return new Ok(false);
-        } else {
-            return new GError(e.code);
-        }
+  try {
+    return new Ok(fs.lstatSync(path.normalize(filepath)).isSymbolicLink());
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return new Ok(false);
+    } else {
+      return new GError(e.code);
     }
+  }
 }
 
 /**
  * Check whether a directory exists at the given path
- * 
- * @param {string} filepath 
- * @returns {Ok | GError} 
+ *
+ * @param {string} filepath
+ * @returns {Ok | GError}
  */
 export function isValidDirectory(filepath) {
-    try {
-        return new Ok(fs.statSync(path.normalize(filepath)).isDirectory());
-    } catch (e) {
-        if (e.code === 'ENOENT') {
-            return new Ok(false);
-        } else {
-            return new GError(e.code);
-        }
+  try {
+    return new Ok(fs.statSync(path.normalize(filepath)).isDirectory());
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      return new Ok(false);
+    } else {
+      return new GError(e.code);
     }
+  }
 }
 
 /**
@@ -102,138 +103,241 @@ export function isValidDirectory(filepath) {
  * @returns {Ok | GError}
  */
 export function makeSymlink(target, path) {
-    return gleamResult(() => fs.symlinkSync(target, path))
+  return gleamResult(() => fs.symlinkSync(target, path));
 }
 
 /**
  * Create a directory at the given filepath
- * 
- * @param {string} filepath 
- * @returns {Ok | GError} 
+ *
+ * @param {string} filepath
+ * @returns {Ok | GError}
  */
 export function makeDirectory(filepath) {
-   return gleamResult(() => fs.mkdirSync(path.normalize(filepath)))
+  return gleamResult(() => fs.mkdirSync(path.normalize(filepath)));
 }
 
 /**
  * Recursively create a directory structure from the given path.
- * 
- * @param {string} filepath 
- * @returns 
+ *
+ * @param {string} filepath
+ * @returns
  */
 export function createDirAll(filepath) {
-    return gleamResult(() => {
-        fs.mkdirSync(path.normalize(filepath), { recursive: true })
-    })
+  return gleamResult(() => {
+    fs.mkdirSync(path.normalize(filepath), { recursive: true });
+  });
 }
 
 /**
  * Recursively delete a directory or delete a file at the given path.
- * 
- * @param {string} fileOrDirPath 
+ *
+ * @param {string} fileOrDirPath
  * @returns {Ok | GError}
  */
 export function deleteFileOrDirRecursive(fileOrDirPath) {
-    return gleamResult(() => {
-        const isDir = isValidDirectory(fileOrDirPath)
-        if (isDir instanceof Ok && isDir[0] === true) {
-            fs.rmSync(path.normalize(fileOrDirPath), { recursive: true })
-        } else {
-            fs.unlinkSync(path.normalize(fileOrDirPath))
-        }
-    })
+  return gleamResult(() => {
+    const isDir = isValidDirectory(fileOrDirPath);
+    if (isDir instanceof Ok && isDir[0] === true) {
+      fs.rmSync(path.normalize(fileOrDirPath), { recursive: true });
+    } else {
+      fs.unlinkSync(path.normalize(fileOrDirPath));
+    }
+  });
 }
 
 /**
  * List the contents of a directory.
- * 
- * @param {string} filepath 
+ *
+ * @param {string} filepath
  * @returns {Ok | GError}
  */
 export function listContents(filepath) {
-    return gleamResult(() => toList(fs.readdirSync(path.normalize(filepath))))
+  return gleamResult(() => toList(fs.readdirSync(path.normalize(filepath))));
 }
 
 /**
  * Copy a file to a new path.
- * 
- * @param {string} srcpath 
- * @param {string} destpath 
+ *
+ * @param {string} srcpath
+ * @param {string} destpath
  * @returns {Ok | GError}
  */
 export function copyFile(srcpath, destpath) {
-    return gleamResult(() => fs.copyFileSync(path.normalize(srcpath), path.normalize(destpath)))
+  return gleamResult(() => fs.copyFileSync(path.normalize(srcpath), path.normalize(destpath)));
 }
 
 /**
  * Move a file to the new path.
- * 
- * @param {string} srcpath 
- * @param {string} destpath 
+ *
+ * @param {string} srcpath
+ * @param {string} destpath
  * @returns {Ok | GError}
  */
 export function renameFile(srcpath, destpath) {
-    return gleamResult(() => fs.renameSync(path.normalize(srcpath), path.normalize(destpath)))
+  return gleamResult(() => fs.renameSync(path.normalize(srcpath), path.normalize(destpath)));
 }
 
 /**
  * Set the file permissions. Octal number should be in base 8.
- * 
- * @param {string} filepath 
- * @param {number} octalNumber 
+ *
+ * @param {string} filepath
+ * @param {number} octalNumber
  * @returns {Ok | GError}
  */
 export function setPermissions(filepath, octalNumber) {
-    return gleamResult(() => fs.chmodSync(path.normalize(filepath), octalNumber))
+  return gleamResult(() => fs.chmodSync(path.normalize(filepath), octalNumber));
 }
 
 /**
  * Return the current directory.
- * 
+ *
  * @returns {Ok | GError} The current directory
  */
 export function currentDirectory() {
-    return gleamResult(() => process.cwd())
+  return gleamResult(() => process.cwd());
 }
 
 /**
- * 
- * @param {string} filepath 
+ *
+ * @param {string} filepath
  * @returns {Ok | GError}
  */
 export function fileInfo(filepath) {
-    return gleamResult(() => new FileInfo(filepath))
+  return gleamResult(() => new FileInfo(filepath));
 }
 
 class FileInfo {
-    constructor(filepath) {
-        const stat = fs.statSync(path.normalize(filepath))
-        this.size = stat.size
-        this.mode = stat.mode
-        this.nlinks = stat.nlink
-        this.inode = stat.ino
-        this.user_id = stat.uid
-        this.group_id = stat.gid
-        this.dev = stat.dev
-        this.atime_seconds = Math.floor(stat.atimeMs / 1000)
-        this.mtime_seconds = Math.floor(stat.mtimeMs / 1000)
-        this.ctime_seconds = Math.floor(stat.ctimeMs / 1000)
-    }
+  constructor(filepath) {
+    const stat = fs.statSync(path.normalize(filepath));
+    this.size = stat.size;
+    this.mode = stat.mode;
+    this.nlinks = stat.nlink;
+    this.inode = stat.ino;
+    this.user_id = stat.uid;
+    this.group_id = stat.gid;
+    this.dev = stat.dev;
+    this.atime_seconds = Math.floor(stat.atimeMs / 1000);
+    this.mtime_seconds = Math.floor(stat.mtimeMs / 1000);
+    this.ctime_seconds = Math.floor(stat.ctimeMs / 1000);
+  }
 }
 
 /**
  * Perform some operation and return a Gleam `Result(a, String)`
  * where `a` is the type returned by the operation and the `String`
  * is the error code.
- * 
- * @param {function():any} op 
+ *
+ * @param {function():any} op
  * @returns {Ok | GError}
  */
 function gleamResult(op) {
-    try {
-        const val = op()
-        return new Ok(val)
-    } catch(e) {
-        return new GError(e.code)
-    }
+  try {
+    const val = op();
+    return new Ok(val);
+  } catch (e) {
+    return new GError(cast_error(e.code));
+  }
+}
+
+function cast_error(error_code) {
+  switch (error_code) {
+    case "EACCES":
+      return new $simplifile.Eacces();
+    case "EAGAIN":
+      return new $simplifile.Eagain();
+    case "EBADF":
+      return new $simplifile.Ebadf();
+    case "EBADMSG":
+      return new $simplifile.Ebadmsg();
+    case "EBUSY":
+      return new $simplifile.Ebusy();
+    case "EDEADLK":
+      return new $simplifile.Edeadlk();
+    case "EDEADLOCK":
+      return new $simplifile.Edeadlock();
+    case "EDQUOT":
+      return new $simplifile.Edquot();
+    case "EEXIST":
+      return new $simplifile.Eexist();
+    case "EFAULT":
+      return new $simplifile.Efault();
+    case "EFBIG":
+      return new $simplifile.Efbig();
+    case "EFTYPE":
+      return new $simplifile.Eftype();
+    case "EINTR":
+      return new $simplifile.Eintr();
+    case "EINVAL":
+      return new $simplifile.Einval();
+    case "EIO":
+      return new $simplifile.Eio();
+    case "EISDIR":
+      return new $simplifile.Eisdir();
+    case "ELOOP":
+      return new $simplifile.Eloop();
+    case "EMFILE":
+      return new $simplifile.Emfile();
+    case "EMLINK":
+      return new $simplifile.Emlink();
+    case "EMULTIHOP":
+      return new $simplifile.Emultihop();
+    case "ENAMETOOLONG":
+      return new $simplifile.Enametoolong();
+    case "ENFILE":
+      return new $simplifile.Enfile();
+    case "ENOBUFS":
+      return new $simplifile.Enobufs();
+    case "ENODEV":
+      return new $simplifile.Enodev();
+    case "ENOLCK":
+      return new $simplifile.Enolck();
+    case "ENOLINK":
+      return new $simplifile.Enolink();
+    case "ENOENT":
+      return new $simplifile.Enoent();
+    case "ENOMEM":
+      return new $simplifile.Enomem();
+    case "ENOSPC":
+      return new $simplifile.Enospc();
+    case "ENOSR":
+      return new $simplifile.Enosr();
+    case "ENOSTR":
+      return new $simplifile.Enostr();
+    case "ENOSYS":
+      return new $simplifile.Enosys();
+    case "ENOBLK":
+      return new $simplifile.Enotblk();
+    case "ENODIR":
+      return new $simplifile.Enotdir();
+    case "ENOTSUP":
+      return new $simplifile.Enotsup();
+    case "ENXIO":
+      return new $simplifile.Enxio();
+    case "EOPNOTSUPP":
+      return new $simplifile.Eopnotsupp();
+    case "EOVERFLOW":
+      return new $simplifile.Eoverflow();
+    case "EPERM":
+      return new $simplifile.Eperm();
+    case "EPIPE":
+      return new $simplifile.Epipe();
+    case "ERANGE":
+      return new $simplifile.Erange();
+    case "EROFS":
+      return new $simplifile.Erofs();
+    case "ESPIPE":
+      return new $simplifile.Espipe();
+    case "ESRCH":
+      return new $simplifile.Esrch();
+    case "ESTALE":
+      return new $simplifile.Estale();
+    case "ETXTBSY":
+      return new $simplifile.Etxtbsy();
+    case "EXDEV":
+      return new $simplifile.Exdev();
+    case "NOTUTF8":
+      return new $simplifile.NotUtf8();
+    default:
+      return new $simplifile.Unknown(error_code);
+  }
 }


### PR DESCRIPTION
Hello! I noticed `simplifile` uses quite a lot of `target` annotations, that is [highly discouraged](https://discord.com/channels/768594524158427167/768594524158427170/1255187144386023577).

simplifile is a great package and my guess is a lot of people interested in ffi will probably have a look at its source code so I think it's for the best to follow Louis' recommendation to never use `target` and set a good example on how to write ffi for two targets at the same time.

This PR:
- removes the target annotation by moving the error casting in the JS-specific code (rather than implementing it in Gleam and having it as a no-op for the erlang target)
- renames the external functions to match the corresponding Gleam definitions