### PR TITLE
feat: resolve path function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add `resolve` function, which resolves relative paths to absolute paths based on the current working directory.
 
 ## v2.3.2 - 26 December 2025 
 - Fix bug where unknown errors were not properly converted to the Unknown variant in Erlang ffi.

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,7 +4,7 @@ description = "Basic file operations that work on all targets"
 
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "bcpeinhardt", repo = "simplifile" }
-gleam = ">= 1.9.0"
+gleam = ">= 1.11.0"
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [javascript.deno]

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -744,24 +744,23 @@ pub fn current_directory() -> Result(String, FileError) {
 @external(erlang, "file", "get_cwd")
 fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 
-/// Converts a relative path to an absolute path.
-///
-/// Prepends the current working directory to the result if the path doesn't start at the drive root.
-/// (`/` or `c:/` or `d:/`, etc.). An empty path returns the current working directory.
+/// Converts a relative path to an absolute path which starts in the current working directory.
 ///
 /// Returns an error if the relative path could not be resolved.
 /// 
 /// # Example:
 /// ```gleam
-/// // on Unix(-like)
-/// assert resolve("/var/lib/../lucy/./gleam") == Ok("/var/lucy/gleam")
+/// // Resolving a relative path resolves the full absolute path.
+/// // Assume the current working directory is /home/lucy.
+/// assert resolve("./tmp/../gleam") == Ok("$/home/lucy/gleam")
+///
+/// // On Windows.
+/// // Assume the current working directory is c:\users\lucy.
+/// assert resolve(".\\tmp\\..\\gleam") == Ok("$c:\\users\\lucy\\gleam")
+///
+/// // Resolving an absolute path returns that absolute path.
+/// assert resolve("/tmp/gleam") == Ok("/tmp/gleam")
 /// 
-/// // on Windows
-/// assert resolve("c:\\var\\lib\\..\\lucy\\.\\gleam") == Ok("c:\\var\\lucy\\gleam") 
-///
-/// // if the current working directory is `/home/something`
-/// assert resolve("../gleam") == Ok("/home/gleam") 
-///
 /// // Tried to go two directories back, but was only able to go one back. Path is unresolvable.
 /// assert resolve("/tmp/../..") == Error(Enoent) 
 /// ```

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -754,10 +754,6 @@ fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 /// // Assume the current working directory is /home/lucy.
 /// assert resolve("./tmp/../gleam") == Ok("$/home/lucy/gleam")
 ///
-/// // On Windows.
-/// // Assume the current working directory is c:\users\lucy.
-/// assert resolve(".\\tmp\\..\\gleam") == Ok("$c:\\users\\lucy\\gleam")
-///
 /// // Resolving an absolute path returns that absolute path.
 /// assert resolve("/tmp/gleam") == Ok("/tmp/gleam")
 /// 

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -743,3 +743,33 @@ pub fn current_directory() -> Result(String, FileError) {
 
 @external(erlang, "file", "get_cwd")
 fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
+
+/// Converts a relative path to an absolute path.
+///
+/// Prepends the current working directory to the result if the path doesn't start at the drive root.
+/// (`/` or `c:/` or `d:/`, etc.)
+///
+/// Returns an error if the relative path could not be resolved.
+/// 
+/// # Example:
+/// ```gleam
+/// // on Unix(-like)
+/// assert resolve("/var/lib/../lucy/./gleam") == Ok("/var/lucy/gleam")
+/// 
+/// // on Windows
+/// assert resolve("/var/lib/../lucy/./gleam") == Ok("c:/var/lucy/gleam") 
+///
+/// // if the current working directory is `/home/something`
+/// assert resolve("../gleam") == Ok("/home/gleam") 
+///
+/// // Tried to go two directories back, but was only able to go one back. Path is unresolvable.
+/// assert resolve("/tmp/../..") == Error(Nil) 
+/// ```
+pub fn resolve(path path: String) -> Result(String, Nil) {
+  do_resolve(path)
+  |> filepath.expand
+}
+
+@external(erlang, "filename", "absname")
+@external(javascript, "./simplifile_js.mjs", "resolve")
+fn do_resolve(path: String) -> String

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -757,7 +757,7 @@ fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 /// assert resolve("/var/lib/../lucy/./gleam") == Ok("/var/lucy/gleam")
 /// 
 /// // on Windows
-/// assert resolve("/var/lib/../lucy/./gleam") == Ok("c:/var/lucy/gleam") 
+/// assert resolve("c:\\var\\lib\\..\\lucy\\.\\gleam") == Ok("c:\\var\\lucy\\gleam") 
 ///
 /// // if the current working directory is `/home/something`
 /// assert resolve("../gleam") == Ok("/home/gleam") 

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -747,7 +747,7 @@ fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 /// Converts a relative path to an absolute path.
 ///
 /// Prepends the current working directory to the result if the path doesn't start at the drive root.
-/// (`/` or `c:/` or `d:/`, etc.)
+/// (`/` or `c:/` or `d:/`, etc.). An empty path returns the current working directory.
 ///
 /// Returns an error if the relative path could not be resolved.
 /// 
@@ -763,11 +763,12 @@ fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 /// assert resolve("../gleam") == Ok("/home/gleam") 
 ///
 /// // Tried to go two directories back, but was only able to go one back. Path is unresolvable.
-/// assert resolve("/tmp/../..") == Error(Nil) 
+/// assert resolve("/tmp/../..") == Error(Enoent) 
 /// ```
-pub fn resolve(path path: String) -> Result(String, Nil) {
+pub fn resolve(path path: String) -> Result(String, FileError) {
   do_resolve(path)
   |> filepath.expand
+  |> result.replace_error(Enoent)
 }
 
 @external(erlang, "filename", "absname")

--- a/src/simplifile.gleam
+++ b/src/simplifile.gleam
@@ -752,7 +752,7 @@ fn erl_do_current_directory() -> Result(List(UtfCodepoint), FileError)
 /// ```gleam
 /// // Resolving a relative path resolves the full absolute path.
 /// // Assume the current working directory is /home/lucy.
-/// assert resolve("./tmp/../gleam") == Ok("$/home/lucy/gleam")
+/// assert resolve("./tmp/../gleam") == Ok("/home/lucy/gleam")
 ///
 /// // Resolving an absolute path returns that absolute path.
 /// assert resolve("/tmp/gleam") == Ok("/tmp/gleam")

--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -398,3 +398,7 @@ function cast_error(error_code) {
       return new $simplifile.Unknown(error_code);
   }
 }
+
+export function resolve(file_path) {
+  return path.resolve(file_path);
+} 

--- a/src/simplifile_js.mjs
+++ b/src/simplifile_js.mjs
@@ -399,6 +399,12 @@ function cast_error(error_code) {
   }
 }
 
-export function resolve(file_path) {
-  return path.resolve(file_path);
+/**
+ * Resolves a relative path to an absolute path based on the current working directory.
+ * 
+ * @param {string} filepath The file path to resolve
+ * @returns {string} The resolved file path
+ */
+export function resolve(filepath) {
+  return path.resolve(filepath);
 } 

--- a/test/simplifile_test.gleam
+++ b/test/simplifile_test.gleam
@@ -1,5 +1,6 @@
 import gleam/int
 import gleam/list
+import gleam/result
 import gleam/set
 import gleam/string
 import gleeunit
@@ -781,3 +782,9 @@ pub fn unknown_errors_return_unknown_test() {
 @external(erlang, "simplifile_erl", "create_directory")
 @external(javascript, "./simplifile_js.mjs", "createDirectory")
 fn create_directory_with_bad_arg(arg: #(Nil, Nil)) -> Result(Nil, FileError)
+
+pub fn resolve_empty_path_test() {
+  assert simplifile.resolve("")
+    == simplifile.current_directory()
+    |> result.replace_error(Nil)
+}

--- a/test/simplifile_test.gleam
+++ b/test/simplifile_test.gleam
@@ -1,6 +1,5 @@
 import gleam/int
 import gleam/list
-import gleam/result
 import gleam/set
 import gleam/string
 import gleeunit
@@ -784,7 +783,21 @@ pub fn unknown_errors_return_unknown_test() {
 fn create_directory_with_bad_arg(arg: #(Nil, Nil)) -> Result(Nil, FileError)
 
 pub fn resolve_empty_path_test() {
-  assert simplifile.resolve("")
-    == simplifile.current_directory()
-    |> result.replace_error(Nil)
+  assert simplifile.resolve("") == simplifile.current_directory()
+}
+
+pub fn resolve_relative_path_test() {
+  let assert Ok(actual) = simplifile.resolve("./simplifile_test.gleam")
+  let assert Ok(cwd) = simplifile.current_directory()
+  let expected = cwd <> "/simplifile_test.gleam"
+
+  assert actual == expected
+}
+
+// only works on Unix(-like) systems
+pub fn resolve_absolute_path_test() {
+  let initial = "/bin/hello"
+  let assert Ok(actual) = simplifile.resolve(initial)
+
+  assert initial == actual
 }


### PR DESCRIPTION
Created a function - `simplifile.resolve(path)`, which will resolve a relative path to an absolute path through a FFI and expands the path.

Also updated the Gleam version to avoid using the deprecated `gleeunit/should` module. I wanted to implement more tests, but most of them pretty much fail on Windows.

Closes #57 